### PR TITLE
Feature/data homepage

### DIFF
--- a/frontend/homepage.html
+++ b/frontend/homepage.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href='https://fonts.googleapis.com/css?family=Poppins' rel='stylesheet'>
-    <link rel="stylesheet" href="./styles.css">
+    <link rel="stylesheet" href="./styles-homepage.css">
     <title>Quiz app</title>
 </head>
 
@@ -27,21 +27,19 @@
 
         <div class="quiz-section">
             <div class="quiz-options" id="quizzes-container">
-                <div class="quiz-option">
+                <!-- <div class="quiz-option">
                     <img src="./images/c++.png" alt="C++">
                     <p>C++</p>
                 </div>
-
+                
                 <div class="quiz-option">
-                    <a href="http://www.google.com" target="_blank">
-                        <img src="./images/python.png" alt="Python">
-                        <p>Python</p>
-                    </a>
+                    <img src="./images/python.png" alt="Python">
+                    <p>Python</p>
                 </div>
                 <div class="quiz-option">
                     <img src="./images/java.png" alt="Java">
                     <p>Java</p>
-                </div>
+                </div> -->
             </div>
         </div>
     </div>

--- a/frontend/homepage.html
+++ b/frontend/homepage.html
@@ -26,14 +26,17 @@
     <div class="content">
 
         <div class="quiz-section">
-            <div class="quiz-options">
+            <div class="quiz-options" id="quizzes-container">
                 <div class="quiz-option">
                     <img src="./images/c++.png" alt="C++">
                     <p>C++</p>
                 </div>
+
                 <div class="quiz-option">
-                    <img src="./images/python.png" alt="Python">
-                    <p>Python</p>
+                    <a href="http://www.google.com" target="_blank">
+                        <img src="./images/python.png" alt="Python">
+                        <p>Python</p>
+                    </a>
                 </div>
                 <div class="quiz-option">
                     <img src="./images/java.png" alt="Java">

--- a/frontend/homepage.html
+++ b/frontend/homepage.html
@@ -27,25 +27,9 @@
 
         <div class="quiz-section">
             <div class="quiz-options" id="quizzes-container">
-                <!-- <div class="quiz-option">
-                    <img src="./images/c++.png" alt="C++">
-                    <p>C++</p>
-                </div>
-                
-                <div class="quiz-option">
-                    <img src="./images/python.png" alt="Python">
-                    <p>Python</p>
-                </div>
-                <div class="quiz-option">
-                    <img src="./images/java.png" alt="Java">
-                    <p>Java</p>
-                </div> -->
             </div>
         </div>
     </div>
-
-    <!-- Button to trigger the API call -->
-    <div><button id="apiButton">Call API</button></div>
 
     <div id="quiz-options-container"></div>
 
@@ -58,11 +42,6 @@
     <footer class="footer">
         <h4>Quiz app</h4>
     </footer>
-
-
-
-
-
 </body>
 
 </html>

--- a/frontend/homepage.html
+++ b/frontend/homepage.html
@@ -42,9 +42,24 @@
             </div>
         </div>
     </div>
+
+    <!-- Button to trigger the API call -->
+    <div><button id="apiButton">Call API</button></div>
+
+    <div id="quiz-options-container"></div>
+
+    <!-- Link to the external JavaScript file -->
+    <script src="script.js"></script>
+
+    <div><br><br><br></div>
+
+
     <footer class="footer">
         <h4>Quiz app</h4>
     </footer>
+
+
+
 
 
 </body>

--- a/frontend/quiz_description.html
+++ b/frontend/quiz_description.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quiz Description</title>
+</head>
+
+<body>
+    <h1>Quiz Description</h1>
+    <div id="quiz-description"></div>
+
+    <script>
+        // Function to extract query parameters
+        function getQueryParam(param) {
+            const urlParams = new URLSearchParams(window.location.search);
+            return urlParams.get(param);
+        }
+
+        // Get the quiz ID from the URL
+        const quizId = getQueryParam('quizId');
+        console.log(quizId);
+
+
+        // Fetch and display quiz description dynamically based on the quiz ID
+        if (quizId) {
+            document.getElementById('quiz-description').innerText = quizId
+        } else {
+            document.getElementById('quiz-description').innerText = 'No quiz selected.';
+        }
+    </script>
+</body>
+
+</html>

--- a/frontend/quiz_description.html
+++ b/frontend/quiz_description.html
@@ -9,10 +9,11 @@
 
 <body>
     <h1>Quiz Description</h1>
-    <div id="quiz-description"></div>
+    <div id="quiz-description">Selected quiz: </div>
 
     <script>
-        // Function to extract query parameters
+        // Function to extract query parameters (the quiz id) from the homepage
+        // Consider moving to the script.js file
         function getQueryParam(param) {
             const urlParams = new URLSearchParams(window.location.search);
             return urlParams.get(param);
@@ -22,10 +23,9 @@
         const quizId = getQueryParam('quizId');
         console.log(quizId);
 
-
-        // Fetch and display quiz description dynamically based on the quiz ID
+        // TODO: Fetch and display quiz description dynamically based on the quiz ID
         if (quizId) {
-            document.getElementById('quiz-description').innerText = quizId
+            document.getElementById('quiz-description').innerText += quizId
         } else {
             document.getElementById('quiz-description').innerText = 'No quiz selected.';
         }

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,59 @@
+// Call the API to get all quizzes
+async function fetchQuizzes() {
+    const apiUrl = 'http://localhost:3000/dev/quiz';
+
+    try {
+        const response = await fetch(apiUrl);
+
+        // Check if the response was successful
+        if (!response.ok) {
+            throw new Error(`Network response was not ok: ${response.statusText}`);
+        }
+
+        const data = await response.json(); // Parse JSON response
+        return data; // Return the data to be used elsewhere
+    } catch (error) {
+        console.error('Fetch error:', error);
+        throw error; // Propagate error if needed
+    }
+}
+
+// Add event listener to the button to call the fetchQuizzes function
+document.getElementById('apiButton').addEventListener('click', async () => {
+    try {
+        const apiData = await fetchQuizzes();
+        // const quizData = JSON.parse(apiData);
+        // console.log(apiData);
+        document.getElementById('quizTitle').innerText = quizData;
+
+        // document.getElementById('quizTitle').innerText = JSON.stringify(apiData['quizzes'][1]['title'], null, 2).replace(/['"]+/g, '');
+        document.getElementById('quizTitle').innerText = JSON.stringify(apiData['quizzes'][1]['title'], null, 2).replace(/['"]+/g, '');
+        document.getElementById('apiResponse').innerText = JSON.stringify(apiData, null, 2);
+
+        // Get the parent container element
+        const container = document.getElementById('quiz-options-container')
+
+        // Create and append 5 new div elements in a loop
+        for (let i = 1; i <= 3; i++) {
+            // Create a new div element
+            const newDiv = document.createElement('div');
+
+            // Set the content of the new div
+            newDiv.innerText = `This is div number ${i}`;
+
+            // Optionally, set some attributes or styles
+            newDiv.setAttribute('class', 'dynamic-div');
+            newDiv.style.padding = '10px';
+            newDiv.style.border = '1px solid black';
+            newDiv.style.marginBottom = '5px';
+
+            // Append the new div to the container
+            container.appendChild(newDiv);
+        }
+
+
+
+    } catch (error) {
+        console.error('Error handling API data:', error);
+    }
+});

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -18,42 +18,98 @@ async function fetchQuizzes() {
     }
 }
 
+// For testing purposes
+const imagePaths = ["images/c++.png", "images/python.png", "images/java.png"];
+const imageAltTexts = ["C++", "Python", "Java"];
+
 // Add event listener to the button to call the fetchQuizzes function
 document.getElementById('apiButton').addEventListener('click', async () => {
     try {
-        const apiData = await fetchQuizzes();
+        const quizData = await fetchQuizzes();
         // const quizData = JSON.parse(apiData);
-        // console.log(apiData);
-        document.getElementById('quizTitle').innerText = quizData;
-
-        // document.getElementById('quizTitle').innerText = JSON.stringify(apiData['quizzes'][1]['title'], null, 2).replace(/['"]+/g, '');
-        document.getElementById('quizTitle').innerText = JSON.stringify(apiData['quizzes'][1]['title'], null, 2).replace(/['"]+/g, '');
-        document.getElementById('apiResponse').innerText = JSON.stringify(apiData, null, 2);
+        console.log(quizData);
+        // document.getElementById('jsonTest').innerText = quizData['quizzes'][1]['title'];
 
         // Get the parent container element
-        const container = document.getElementById('quiz-options-container')
+        const quizzesContainer = document.getElementById('quizzes-container')
 
-        // Create and append 5 new div elements in a loop
-        for (let i = 1; i <= 3; i++) {
-            // Create a new div element
-            const newDiv = document.createElement('div');
+        // Create and append 3 new div elements in a loop
+        for (let i = 0; i < quizData['quizzes'].length; i++) {
+            // Temporary limit until we implement pagination/arrows
+            if (i < 3) {
+                // Element for the quiz option (tile that inlcudes image and title)
+                const quizOption = document.createElement('div');
 
-            // Set the content of the new div
-            newDiv.innerText = `This is div number ${i}`;
+                let quizImage = document.createElement('img');
 
-            // Optionally, set some attributes or styles
-            newDiv.setAttribute('class', 'dynamic-div');
-            newDiv.style.padding = '10px';
-            newDiv.style.border = '1px solid black';
-            newDiv.style.marginBottom = '5px';
+                // For testing purposes
+                quizImage.src = imagePaths[i % 3];
+                quizImage.alt = imageAltTexts[i % 3];
 
-            // Append the new div to the container
-            container.appendChild(newDiv);
+
+                var quizTitle = document.createElement('a');
+                quizTitle.setAttribute('href', "yourlink.htm");
+                quizTitle.innerText = quizData['quizzes'][i]['title'];
+
+                // const quizTitle = document.createElement('p');
+                // quizTitle.innerText = quizData['quizzes'][i]['title'];
+
+                quizOption.appendChild(quizImage);
+                quizOption.appendChild(quizTitle);
+
+                quizOption.setAttribute('class', 'quiz-option');
+                // quizOption.style.padding = '10px';
+                // quizOption.style.border = '1px solid black';
+                // quizOption.style.marginBottom = '5px';
+
+                // Append the new div to the container
+                quizzesContainer.appendChild(quizOption);
+            }
         }
-
-
-
     } catch (error) {
         console.error('Error handling API data:', error);
     }
 });
+
+
+
+
+
+// // Add event listener to the button to call the fetchQuizzes function
+// document.getElementById('apiButton').addEventListener('click', async () => {
+//     try {
+//         const quizData = await fetchQuizzes();
+//         // const quizData = JSON.parse(apiData);
+//         console.log(quizData);
+//         // document.getElementById('jsonTest').innerText = quizData['quizzes'][1]['title'];
+
+//         // Get the parent container element
+//         const container = document.getElementById('quiz-options-container')
+
+//         // Create and append 5 new div elements in a loop
+//         for (let i = 0; i < quizData['quizzes'].length; i++) {
+//             // Create a new div element
+//             const newDiv = document.createElement('div');
+
+//             // Set the content of the new div
+//             newDiv.innerText = quizData['quizzes'][i]['title'] + ' ' + quizData['quizzes'][i]['quizId'];
+
+//             // Optionally, set some attributes or styles
+//             newDiv.setAttribute('class', 'dynamic-div');
+//             newDiv.style.padding = '10px';
+//             newDiv.style.border = '1px solid black';
+//             newDiv.style.marginBottom = '5px';
+
+//             // Append the new div to the container
+//             container.appendChild(newDiv);
+//         }
+//     } catch (error) {
+//         console.error('Error handling API data:', error);
+//     }
+// });
+
+
+
+
+
+

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,117 +1,63 @@
-// Call the API to get all quizzes
-async function fetchQuizzes() {
-    const apiUrl = 'http://localhost:3000/dev/quiz';
+// Add a listener to the init function, so it runs when the DOM is fully loaded
+// This ensures that the API call and displaying of quizzes happens as soon as possible
+document.addEventListener('DOMContentLoaded', init);
 
-    try {
-        const response = await fetch(apiUrl);
-
-        // Check if the response was successful
-        if (!response.ok) {
-            throw new Error(`Network response was not ok: ${response.statusText}`);
-        }
-
-        const data = await response.json(); // Parse JSON response
-        return data; // Return the data to be used elsewhere
-    } catch (error) {
-        console.error('Fetch error:', error);
-        throw error; // Propagate error if needed
-    }
+function init() {
+    getQuizzes()
+        .then(data => displayQuizzes(data))  // Pass the fetched data to the display function
+        .catch(error => {
+            console.error('Error fetching quizzes:', error);
+        });
 }
 
-// For testing purposes
-const imagePaths = ["images/c++.png", "images/python.png", "images/java.png"];
-const imageAltTexts = ["C++", "Python", "Java"];
-
-// Add event listener to the button to call the fetchQuizzes function
-document.getElementById('apiButton').addEventListener('click', async () => {
-    try {
-        const quizData = await fetchQuizzes();
-        // const quizData = JSON.parse(apiData);
-        console.log(quizData);
-        // document.getElementById('jsonTest').innerText = quizData['quizzes'][1]['title'];
-
-        // Get the parent container element
-        const quizzesContainer = document.getElementById('quizzes-container')
-
-        const quizDescriptionParameter = 'quiz_description.html?quizId=';
-
-        // Create and append 3 new div elements in a loop
-        for (let i = 0; i < quizData['quizzes'].length; i++) {
-            // Temporary limit until we implement pagination/arrows
-            if (i < 3) {
-                // Element for the quiz option (tile that inlcudes image and title)
-                const quizOption = document.createElement('div');
-
-                let quizImage = document.createElement('img');
-
-                // For testing purposes
-                quizImage.src = imagePaths[i % 3];
-                quizImage.alt = imageAltTexts[i % 3];
-
-                var quizTitle = document.createElement('a');
-                quizTitle.setAttribute('href', quizDescriptionParameter + quizData['quizzes'][i]['quizId']);
-
-                quizTitle.innerText = quizData['quizzes'][i]['title'];
-
-                // const quizTitle = document.createElement('p');
-                // quizTitle.innerText = quizData['quizzes'][i]['title'];
-
-                quizOption.appendChild(quizImage);
-                quizOption.appendChild(quizTitle);
-
-                quizOption.setAttribute('class', 'quiz-option');
-                // quizOption.style.padding = '10px';
-                // quizOption.style.border = '1px solid black';
-                // quizOption.style.marginBottom = '5px';
-
-                // Append the new div to the container
-                quizzesContainer.appendChild(quizOption);
+// Function to get quizzes from the API
+function getQuizzes() {
+    return fetch('http://localhost:3000/dev/quiz')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
             }
+            return response.json(); // Parse JSON data
+        });
+}
+
+// Function to display the quizzes in the quiz-options element
+function displayQuizzes(quizzes) {
+    // This is for testing purposes, we should instead use a map
+    // e.g. quizImagesMap={ 'python' : 'images /python. Png' }
+    const imagePaths = ["images/c++.png", "images/python.png", "images/java.png"];
+    const imageAltTexts = ["C++", "Python", "Java"];
+
+    // Get the parent container element (quiz-options)
+    const quizzesContainer = document.getElementById('quizzes-container')
+    const quizDescriptionParameter = 'quiz_description.html?quizId=';
+
+    // Create and append 3 new div elements in a loop
+    // This is a temporary limit until we implement pagination/arrows or another approach
+    // We should then change the for loop to a foreach, to improve code readability
+    for (let i = 0; i < quizzes['quizzes'].length; i++) {
+        if (i < 3) {
+            // Element for the quiz option (tile that includes image and title)
+            const quizOption = document.createElement('div');
+
+            let quizImage = document.createElement('img');
+
+            // For testing purposes (for loopoing between the already available images)
+            quizImage.src = imagePaths[i % 3];
+            quizImage.alt = imageAltTexts[i % 3];
+
+            var quizTitle = document.createElement('a');
+            quizTitle.setAttribute('href', quizDescriptionParameter + quizzes['quizzes'][i]['quizId']);
+            quizTitle.innerText = quizzes['quizzes'][i]['title'];
+
+            // Add image and anchor elements to their parent element - quiz-options
+            quizOption.appendChild(quizImage);
+            quizOption.appendChild(quizTitle);
+
+            quizOption.setAttribute('class', 'quiz-option');
+
+            // Append the quiz-option div to the container (quiz-options)
+            quizzesContainer.appendChild(quizOption);
         }
-    } catch (error) {
-        console.error('Error handling API data:', error);
     }
-});
-
-
-
-
-
-// // Add event listener to the button to call the fetchQuizzes function
-// document.getElementById('apiButton').addEventListener('click', async () => {
-//     try {
-//         const quizData = await fetchQuizzes();
-//         // const quizData = JSON.parse(apiData);
-//         console.log(quizData);
-//         // document.getElementById('jsonTest').innerText = quizData['quizzes'][1]['title'];
-
-//         // Get the parent container element
-//         const container = document.getElementById('quiz-options-container')
-
-//         // Create and append 5 new div elements in a loop
-//         for (let i = 0; i < quizData['quizzes'].length; i++) {
-//             // Create a new div element
-//             const newDiv = document.createElement('div');
-
-//             // Set the content of the new div
-//             newDiv.innerText = quizData['quizzes'][i]['title'] + ' ' + quizData['quizzes'][i]['quizId'];
-
-//             // Optionally, set some attributes or styles
-//             newDiv.setAttribute('class', 'dynamic-div');
-//             newDiv.style.padding = '10px';
-//             newDiv.style.border = '1px solid black';
-//             newDiv.style.marginBottom = '5px';
-
-//             // Append the new div to the container
-//             container.appendChild(newDiv);
-//         }
-//     } catch (error) {
-//         console.error('Error handling API data:', error);
-//     }
-// });
-
-
-
-
-
-
+}

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -33,6 +33,8 @@ document.getElementById('apiButton').addEventListener('click', async () => {
         // Get the parent container element
         const quizzesContainer = document.getElementById('quizzes-container')
 
+        const quizDescriptionParameter = 'quiz_description.html?quizId=';
+
         // Create and append 3 new div elements in a loop
         for (let i = 0; i < quizData['quizzes'].length; i++) {
             // Temporary limit until we implement pagination/arrows
@@ -46,9 +48,9 @@ document.getElementById('apiButton').addEventListener('click', async () => {
                 quizImage.src = imagePaths[i % 3];
                 quizImage.alt = imageAltTexts[i % 3];
 
-
                 var quizTitle = document.createElement('a');
-                quizTitle.setAttribute('href', "yourlink.htm");
+                quizTitle.setAttribute('href', quizDescriptionParameter + quizData['quizzes'][i]['quizId']);
+
                 quizTitle.innerText = quizData['quizzes'][i]['title'];
 
                 // const quizTitle = document.createElement('p');

--- a/frontend/styles-homepage.css
+++ b/frontend/styles-homepage.css
@@ -1,0 +1,121 @@
+:root {
+    --header: #a262e3;
+}
+
+html,
+body {
+    height: 100%;
+    font-family: 'Poppins';
+    font-size: 22px;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    margin: 0%;
+
+    /* text-align: center;
+      justify-content: center; */
+}
+
+.header {
+    background-color: var(--header);
+    height: 70%;
+    color: white;
+
+    padding: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#navlist {
+    position: absolute;
+    width: 100%;
+    top: 1%;
+
+
+}
+
+.navlist-right {
+
+    float: right;
+    margin: 1%;
+}
+
+.logo img {
+    width: 90px;
+    height: 90px;
+}
+
+.navlist-right img {
+    width: 40px;
+    height: 40px;
+}
+
+.content {
+    flex: 1 0 auto;
+    padding: 20px;
+}
+
+.footer {
+    background-color: var(--header);
+    color: white;
+    display: flex;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 5px;
+}
+
+.quiz-section {
+    position: relative;
+    top: -100px;
+    right: 20px;
+    z-index: 20;
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.quiz-options {
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+    max-width: 800px;
+}
+
+.quiz-option {
+    background-color: white;
+    margin: 30px;
+    width: 316px;
+    height: 316px;
+    border-radius: 12px;
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: transform 0.3s ease;
+}
+
+.quiz-option img {
+    width: 100px;
+    height: 100px;
+    margin-top: 40%;
+    margin-bottom: 20px;
+}
+
+.quiz-option p {
+    font-size: 18px;
+    color: #5d4b9f;
+}
+
+.quiz-option:hover {
+    transform: translateY(-10px);
+}
+
+a {
+    text-decoration: none;
+    color: #5d4b9f;
+    text-align: center;
+}


### PR DESCRIPTION
Added the following functionality:
- On page load:
  - Make an API call to get all quizzes
  - Create elements dynamically and add an image and quiz title
- When clicking on each quiz title:
  - Send the selected quiz id to the description page
  - Navigate to the quiz description page and show selected ID (this behaviour will change, was just for testing purposes)

Some notes:
- The code isn't final, and some changes need to be performed after we discuss them:
  - **Image handling**: where will we store images and how will we represent them?
  - **Pagination**: Right now, only 3 quizzes are shown, even though we have more. This is by design, until we agree on a way to show more quizzes (e.g. pagination, arrows, carousels, etc.)
  - **CSS**: I created another css file and linked it to the homepage, so that I don't make breaking changes to the design. Once we agree on all changes and we have our final CSS files for all pages we can merge them.

**Testing**
If you want to test the implementation (you should 😄 ), you can follow these steps (there are of course other ways):
- create a new local branch and link it to this remote tracking branch: `git switch -C feature/data-homepage origin/feature/data-homepage`
- run serverless offline: `sls offline`
- click the live preview extension icon (show preview) and copy the url and paste it to Chrome (I do this instead of testing directly in the preview window, as sometimes it's not responding as expected)