### PR TITLE
Add s3-sync configuration.

### DIFF
--- a/codecrafters/serverless.yml
+++ b/codecrafters/serverless.yml
@@ -8,6 +8,7 @@ provider:
   name: aws
   runtime: python3.12
   region: eu-north-1
+  stage: dev
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -22,6 +23,13 @@ provider:
 plugins:
   # To install this serverless plugin install -n serverless-offline, and then you can run locally using serverless offline (you need to install serverless@3)
   - serverless-offline
+  - serverless-s3-sync
+
+custom:
+  s3Sync:
+    - bucketName: ${self:service}-${opt:stage, self:provider.stage}-website # e.g. codecrafters-dev-website
+      localDir: ../frontend # Your local static files directory (e.g., public or dist)
+      bucketPrefix: '' # Leave blank to sync at the root of the bucket
 
 functions:
   seedData:
@@ -129,3 +137,32 @@ resources:
         # Table-level Encryption (Optional)
         SSESpecification:
           SSEEnabled: true
+
+    WebsiteBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:service}-${opt:stage, self:provider.stage}-website
+        WebsiteConfiguration:
+          IndexDocument: homepage.html
+          ErrorDocument: error.html
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: false
+          BlockPublicPolicy: false
+
+    BucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket:
+          Ref: WebsiteBucket
+        PolicyDocument:
+          Statement:
+            - Effect: Allow
+              Principal: '*'
+              Action: 's3:GetObject'
+              Resource: 'arn:aws:s3:::${self:service}-${opt:stage, self:provider.stage}-website/*'
+
+  Outputs:
+    WebsiteURL:
+      Value:
+        Fn::GetAtt: [WebsiteBucket, WebsiteURL]
+      Description: URL of the static website


### PR DESCRIPTION
- Installed the s3-sync plugin: `npm install serverless-s3-sync --legacy-peer-deps`. The `legacy-peer-deps` parametre is used to [avoid a dependency conflict](https://stackoverflow.com/a/69259680/9434466) with `serverless-offline`.
- Configured the s3-sync plugin, and added necessary permissions to [override the access control lists](https://stackoverflow.com/a/76120035/9434466) from the AWS Console.
- To see the newly created bucket you can visit [this link](https://eu-north-1.console.aws.amazon.com/s3/buckets/codecrafters-dev-website?region=eu-north-1&bucketType=general&tab=objects).





